### PR TITLE
Add support for more Python versions on Github actions and last two versions on Ubuntu

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,8 +4,18 @@ on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9, pypy3]
+        os: [
+          ubuntu-20.04,
+          ubuntu-18.04,
+          ubuntu-16.04,
+          macOS-latest,
+          windows-latest,
+        ]
 
     services:
       postgres:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,9 +12,6 @@ jobs:
         os: [
           ubuntu-20.04,
           ubuntu-18.04,
-          ubuntu-16.04,
-          macOS-latest,
-          windows-latest,
         ]
 
     services:


### PR DESCRIPTION
This PR introduces the build and test on two versions of Ubuntu, and 3 version of Python (Python3.9, Python3.8 and PyPy3), so all together, the tests run on 6 combinations.