### PR TITLE
Remove and change obsolete divio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ docker-compose up
 open http://127.0.0.1:8000
 ```
 
-For a more complete how-to guide to this project, see [Deploy a new django CMS project using the Divio quickstart
-repository](https://docs.divio.com/en/latest/how-to/django-cms-deploy-quickstart/) in the [Divio Developer
-Handbook](https://docs.divio.com).
-
 
 ## Customising the project
 
@@ -42,6 +38,7 @@ Options are also available for using Postgres/MySQL, uWSGI/Gunicorn/Guvicorn, et
 
 ## Contribution
 
-This code for this project has been forked from Divio's quickstart repo. We are grateful for their valueable contribution to the code and documentation of this code.
+This code for this project has been forked from Divio's quickstart repo. We are grateful for their valueable contribution to the code and documentation of this code. 
 
-You can follow the original repo [here](https://github.com/divio/django-cms-divio-quickstart/).
+You can follow the original repo [here](https://github.com/divio/django-cms-divio-quickstart/)
+and read their [Divio Developer Handbook](https://docs.divio.com).

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psycopg2==2.8.5
 uwsgi==2.0.19.1
 
 # key requirements for django CMS
-http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms
+http://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
 django-treebeard>=4.0,<5.0
 django-classy-tags>=2.0
 django-sekizai>=2.0
@@ -20,7 +20,7 @@ pytz
 djangocms-admin-style>=2.0,<3.0
 
 # the default CKEditor - optional, but used in most projects
-https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
+https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 
 # some content plugins - optional, but used in most projects
 djangocms-link>=3.0,<4.0


### PR DESCRIPTION
Minor changes in requirements.txt (divio -> django-cms) and README.md (removed obsolete link, and moved handbook reference at the end)