### PR TITLE
Require CMS 3.9 and limit treebeard to 4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psycopg2==2.8.5
 uwsgi==2.0.19.1
 
 # key requirements for django CMS
-django-cms>=3.8,<3.9
+django-cms>=3.9,<4.0
 django-treebeard>=4.0,<5.0
 django-classy-tags>=2.0
 django-sekizai>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ uwsgi==2.0.19.1
 
 # key requirements for django CMS
 django-cms>=3.9,<4.0
-django-treebeard>=4.0,<5.0
+django-treebeard==4.4
 django-classy-tags>=2.0
 django-sekizai>=2.0
 six


### PR DESCRIPTION
Keep CMS up to date with 3.9 and limit treebeard to 4.4 to avoid issues.