### PR TITLE
Update postgres image to 13.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   database_default:
     # Select one of the following db configurations for the database
-    image: postgres:9.6-alpine
+    image: postgres:13.5-alpine
     ports:
       - "5432:5432/tcp"  # allow your local dev env to connect to the db
     environment:


### PR DESCRIPTION
Divio migrated the databases from postgress 9.6 to 13. More info at [their blog](https://www.divio.com/blog/postgres_migration_from_9_6_to_13/).