### PR TITLE
Fix: Bump djangocms-frontend to 1.2.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ djangocms-text-ckeditor>=5.1.2
 
 
 # optional django CMS frontend
-djangocms-frontend
+djangocms-frontend!=1.2.1
 
 django-filer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ djangocms-alias==2.0.0
     # via -r requirements.in
 djangocms-attributes-field==3.0.0
     # via djangocms-frontend
-djangocms-frontend==1.2.1
+djangocms-frontend==1.2.2
     # via -r requirements.in
 djangocms-text-ckeditor==5.1.5
     # via


### PR DESCRIPTION
This PR bumps the version of djangocms-frontend to 1.2.2 since 1.2.1 is broken. It references non-existing static files causing whitenoise to fail.

* https://github.com/django-cms/djangocms-frontend/issues/180