### PR TITLE
feat: Make bootstrap template the default for faster ramp-up

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -132,11 +132,11 @@ THUMBNAIL_PROCESSORS = (
 )
 
 CMS_TEMPLATES = [
+    # Default template that extend base.html, to be used with Bootstrap 5
+    ('bootstrap5.html', 'Bootstrap 5 Demo'),
+
     # a minimal template to get started with
     ('minimal.html', 'Minimal template'),
-
-    # optional templates that extend base.html, to be used with Bootstrap 5
-    ('bootstrap5.html', 'Bootstrap 5 Demo'),
 
     ('whitenoise-static-files-demo.html', 'Static File Demo'),
 ]


### PR DESCRIPTION
Since the quickstart project comes with djangocms-frontend, it might be more intuitive if the default template loaded bootstrap 5.