### PR TITLE
deps: pip-tools version in requirements, fixes #77

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,5 +30,4 @@ djangocms-frontend
 
 django-filer
 
-
-pip-tools  # needed for compilation of this file into requirements.txt, see start of file
+pip-tools>=7.5.2  # needed for compilation of this file into requirements.txt, see start of file

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ pillow==11.2.1
     #   djangocms-text
     #   easy-thumbnails
     #   reportlab
-pip-tools==7.4.1
+pip-tools==7.5.2
     # via -r requirements.in
 psycopg2==2.9.10
     # via -r requirements.in


### PR DESCRIPTION
## Overview

Fix #77 by updating pip-tools from `7.4.1` to `7.5.2`, and pinning the version.[^1]

## Related

- if I performs this change **and** run the command which updates the `requirements.txt`, I get #80
- #78

## Testing

1. `docker compose build web`
2. `docker compose run --rm web pip-compile -U requirements.in -o requirements.txt`[^2]
3. No error.
4. **Has diff bca00eb5 (from [#80](https://github.com/django-cms/django-cms-quickstart/pull/80)).**

[^1]: `7.5.0` was inadequate, error still occurred
[^2]: Differs from [README command](https://github.com/django-cms/django-cms-quickstart/blob/aa65b1d/README.rst?rgh-link-date=2026-01-16T23%3A25%3A37.000Z#updating-requirements) but suggested by contributor in #77 and considered "better" by A.I. (because it overwrites, not appends).